### PR TITLE
Remove left over darken() and red(), green(), blue()

### DIFF
--- a/assets/stylesheets/bootstrap/_jumbotron.scss
+++ b/assets/stylesheets/bootstrap/_jumbotron.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @use "sass:math";
 
 //
@@ -24,7 +26,7 @@
   }
 
   > hr {
-    border-top-color: darken($jumbotron-bg, 10%);
+    border-top-color: color.adjust($jumbotron-bg, $lightness: -10%, $space: hsl);
   }
 
   .container &,

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @use "sass:math";
 
 //
@@ -631,7 +633,7 @@
 
   .navbar-collapse,
   .navbar-form {
-    border-color: darken($navbar-inverse-bg, 7%);
+    border-color: color.adjust($navbar-inverse-bg, $lightness: -7%, $space: hsl);
   }
 
   .navbar-link {

--- a/assets/stylesheets/bootstrap/_popovers.scss
+++ b/assets/stylesheets/bootstrap/_popovers.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 //
 // Popovers
 // --------------------------------------------------
@@ -117,7 +119,7 @@
   margin: 0; // reset heading margin
   font-size: $font-size-base;
   background-color: $popover-title-bg;
-  border-bottom: 1px solid darken($popover-title-bg, 5%);
+  border-bottom: 1px solid color.adjust($popover-title-bg, $lightness: -5%, $space: hsl);
   border-radius: ($border-radius-large - 1) ($border-radius-large - 1) 0 0;
 }
 

--- a/assets/stylesheets/bootstrap/mixins/_forms.scss
+++ b/assets/stylesheets/bootstrap/mixins/_forms.scss
@@ -55,7 +55,7 @@
 // Example usage: change the default blue border and shadow to white for better
 // contrast against a dark gray background.
 @mixin form-control-focus($color: $input-border-focus) {
-  $color-rgba: rgba(red($color), green($color), blue($color), .6);
+  $color-rgba: rgba(color.channel($color, "red", $space: rgb), color.channel($color, "green", $space: rgb), color.channel($color, "blue", $space: rgb), .6);
   &:focus {
     border-color: $color;
     outline: 0;


### PR DESCRIPTION
Sass migrator (and me!) missed some `darken()` calls.

Separately, `red()`, `green()`, `blue()` are also deprecated.