### PR TITLE
Fix `if` deprecation warnings via `sass-migrator`

### DIFF
--- a/assets/stylesheets/bootstrap/_glyphicons.scss
+++ b/assets/stylesheets/bootstrap/_glyphicons.scss
@@ -13,12 +13,12 @@
   // Import the fonts
   @font-face {
     font-family: "Glyphicons Halflings";
-    src: url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.eot"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.eot"));
-    src: url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.eot?#iefix"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.eot?#iefix")) format("embedded-opentype"),
-         url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.woff2"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.woff2")) format("woff2"),
-         url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.woff"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.woff")) format("woff"),
-         url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.ttf"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.ttf")) format("truetype"),
-         url(if(variables.$bootstrap-sass-asset-helper, twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.svg##{variables.$icon-font-svg-id}"), "#{variables.$icon-font-path}#{variables.$icon-font-name}.svg##{variables.$icon-font-svg-id}")) format("svg");
+    src: url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.eot"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.eot"));
+    src: url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.eot?#iefix"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.eot?#iefix")) format("embedded-opentype"),
+         url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.woff2"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.woff2")) format("woff2"),
+         url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.woff"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.woff")) format("woff"),
+         url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.ttf"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.ttf")) format("truetype"),
+         url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-font-path("#{variables.$icon-font-path}#{variables.$icon-font-name}.svg##{variables.$icon-font-svg-id}"); else: "#{variables.$icon-font-path}#{variables.$icon-font-name}.svg##{variables.$icon-font-svg-id}")) format("svg");
   }
 }
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -84,7 +84,7 @@ $headings-color:          inherit !default;
 
 // [converter] If $bootstrap-sass-asset-helper if used, provide path relative to the assets load path.
 // [converter] This is because some asset helpers, such as Sprockets, do not work with file-relative paths.
-$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/") !default;
+$icon-font-path: if(sass($bootstrap-sass-asset-helper): "bootstrap/"; else: "../fonts/bootstrap/") !default;
 
 //** File name for all font files.
 $icon-font-name:          "glyphicons-halflings-regular" !default;

--- a/assets/stylesheets/bootstrap/mixins/_image.scss
+++ b/assets/stylesheets/bootstrap/mixins/_image.scss
@@ -15,7 +15,7 @@
 // Short retina mixin for setting background-image and -size. Note that the
 // spelling of `min--moz-device-pixel-ratio` is intentional.
 @mixin img-retina($file-1x, $file-2x, $width-1x, $height-1x) {
-  background-image: url(if(variables.$bootstrap-sass-asset-helper, twbs-image-path("#{$file-1x}"), "#{$file-1x}"));
+  background-image: url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-image-path("#{$file-1x}"); else: "#{$file-1x}"));
 
   @media
   only screen and (-webkit-min-device-pixel-ratio: 2),
@@ -24,7 +24,7 @@
   only screen and ( min-device-pixel-ratio: 2),
   only screen and ( min-resolution: 192dpi),
   only screen and ( min-resolution: 2dppx) {
-    background-image: url(if(variables.$bootstrap-sass-asset-helper, twbs-image-path("#{$file-2x}"), "#{$file-2x}"));
+    background-image: url(if(sass(variables.$bootstrap-sass-asset-helper): twbs-image-path("#{$file-2x}"); else: "#{$file-2x}"));
     background-size: $width-1x $height-1x;
   }
 }


### PR DESCRIPTION
We were getting deprecation warnings about the `if` statements and how we should prefer standard CSS `if` these days.  This commit is the output of running:

    npx sass-migrator if-function assets/stylesheets/**/*.scss